### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/comparesv.py
+++ b/comparesv.py
@@ -1,5 +1,5 @@
 import os
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 from collections import OrderedDict
 import time
 
@@ -166,8 +166,8 @@ def fuzzy_column_index(header, headers_list, unmapped_header_indices):
         original_index = unmapped_header_indices[index]
         return original_index
 
-    highest = process.extractOne(header, unmapped_headers)
-    if highest[1] < ROW_THRESHOLD:
+    highest = process.extractOne(header, unmapped_headers, score_cutoff=ROW_THRESHOLD)
+    if highest is None:
         return -1
     unmapped_index = unmapped_headers.index(highest[0])
     original_index = unmapped_header_indices[unmapped_index]
@@ -197,9 +197,9 @@ def deep_row_find(row, data2, headers1, headers2, matched_headers, data2_indices
 def fuzzy_row_find(row, data2, headers1, matched_headers, unmapped_indices2):
     row1 = ' '.join(str(x) for x in row)
     unmapped_data2 = [' '.join(str(x) for x in elem) for index, elem in enumerate(data2) if index in unmapped_indices2]
-    highest = process.extractOne(row1, unmapped_data2)
+    highest = process.extractOne(row1, unmapped_data2, score_cutoff=ROW_THRESHOLD)
 
-    if highest[1] < ROW_THRESHOLD:
+    if highest is None:
         return None, None
 
     index = unmapped_data2.index(highest[0])
@@ -252,7 +252,7 @@ def compare_cells(cell1, cell2, comparison_type, ignore_case):
 
     try:
         if comparison_type == 'fuzzy_string':
-            if fuzz.token_set_ratio(cell1, cell2) > CELL_THRESHOLD:
+            if fuzz.token_set_ratio(cell1, cell2, score_cutoff=CELL_THRESHOLD):
                 return True
         elif comparison_type == 'int':
             return int(cell1) == int(cell2)

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setup(
 		'tqdm==4.18.0',
 		'unidecode==1.1.1',
 		'doublemetaphone==0.1',
-		'fuzzywuzzy==0.18.0',
-		'python-Levenshtein==0.12.0'
+		'rapidfuzz==0.9.1'
 	],
 	entry_points={
 		'console_scripts': [


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy